### PR TITLE
:bug: Fix countable object check

### DIFF
--- a/app/Http/Controllers/Views/HomeController.php
+++ b/app/Http/Controllers/Views/HomeController.php
@@ -31,7 +31,7 @@ class HomeController extends Controller
                ->first();
         $things = Thing::where('room_id',$defaultRoom->id)->get();
 
-        if( count($defaultRoom) != 1){
+        if( $defaultRoom === null ){
             return "Default room is missing!";
         }
 


### PR DESCRIPTION
If default_room was not found $defaultRoom resulted as null, so we got "Parameter must be an array or an object that implements Countable" error. 